### PR TITLE
Update black.yml

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,5 +1,5 @@
 name: black-formatter
-on: [push, pull_request]
+on: pull_request
 jobs:
   linter_name:
     name: runner / black


### PR DESCRIPTION
workflows are double running. This makes it so the black formatter only runs once - on PRs. since committing directly to main is shunned, changes go thru a PR.